### PR TITLE
chore(cli): disable sourcemap generation in tsup config

### DIFF
--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
   dts: true,
-  sourcemap: true,
+  sourcemap: false,
   clean: true,
   target: 'node24',
   noExternal: ['@pdfx/shared'],


### PR DESCRIPTION
This pull request makes a small configuration change to the build setup for the CLI package. The only change is disabling source map generation, which may help reduce build size or improve performance. 

* Disabled source map generation in the `tsup.config.ts` file by setting `sourcemap` to `false`.