### PR TITLE
fix: update component count in SEO and UI descriptions to 24

### DIFF
--- a/apps/www/index.html
+++ b/apps/www/index.html
@@ -6,7 +6,7 @@
 
     <!-- Primary SEO -->
     <title>PDFx — shadcn/ui for React PDFs | Copy-Paste PDF Components</title>
-    <meta name="description" content="Copy-paste React PDF components like shadcn/ui. Run `npx @akii09/pdfx-cli add table` and own the code. 20 components, theme system, CLI, invoice & report templates. MIT licensed." />
+    <meta name="description" content="Copy-paste React PDF components like shadcn/ui. Run `npx @akii09/pdfx-cli add table` and own the code. 24 components, theme system, CLI, invoice & report templates. MIT licensed." />
     <meta name="keywords" content="react pdf components, pdf library react, react-pdf, pdf generator react, invoice pdf react, react pdf renderer components, open source pdf react, typescript pdf, pdf ui library" />
     <meta name="author" content="PDFx" />
     <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
@@ -23,7 +23,7 @@
     <meta property="og:site_name" content="PDFx" />
     <meta property="og:url" content="https://pdfx.akashpise.dev" />
     <meta property="og:title" content="PDFx — shadcn/ui for React PDFs" />
-    <meta property="og:description" content="Copy-paste React PDF components built on @react-pdf/renderer. Run `pdfx add table` — component lives in your codebase. 20 components, CLI, themes, templates." />
+    <meta property="og:description" content="Copy-paste React PDF components built on @react-pdf/renderer. Run `pdfx add table` — component lives in your codebase. 24 components, CLI, themes, templates." />
     <meta property="og:image" content="https://pdfx.akashpise.dev/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -58,7 +58,7 @@
         "alternateName": "PDFx React PDF Library",
         "applicationCategory": "DeveloperApplication",
         "applicationSubCategory": "PDF Generator",
-        "description": "Copy-paste React PDF components like shadcn/ui. Run `pdfx add table` and own the code. 20 components, theme system, CLI, invoice & report templates. MIT licensed.",
+        "description": "Copy-paste React PDF components like shadcn/ui. Run `pdfx add table` and own the code. 24 components, theme system, CLI, invoice & report templates. MIT licensed.",
         "url": "https://pdfx.akashpise.dev",
         "downloadUrl": "https://www.npmjs.com/package/@akii09/pdfx-cli",
         "installUrl": "https://pdfx.akashpise.dev/installation",

--- a/apps/www/src/pages/home.tsx
+++ b/apps/www/src/pages/home.tsx
@@ -673,7 +673,7 @@ const features = [
       'Built directly on @react-pdf/renderer. No wrappers, no shims — pixel-perfect output in every viewer.',
   },
   {
-    title: '20 components',
+    title: '24 components',
     description:
       'Tables, charts, headers, footers, signatures, images and more. Everything real-world PDFs actually need.',
   },
@@ -726,7 +726,7 @@ export default function HomePage() {
               >
                 <div className="inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/70 backdrop-blur-sm px-3.5 py-1 text-xs text-muted-foreground mb-8">
                   <span className="h-1.5 w-1.5 rounded-full bg-foreground/50 animate-pulse" />
-                  Open source · MIT · 20 components
+                  Open source · MIT · 24 components
                 </div>
               </motion.div>
 
@@ -786,7 +786,7 @@ export default function HomePage() {
                 transition={{ duration: 0.5, delay: 0.33 }}
                 className="text-xs text-muted-foreground/70 mb-5"
               >
-                Used by 14+ developers · MIT License · No vendor lock-in
+                MIT License · No vendor lock-in
               </motion.p>
 
               <motion.div
@@ -821,7 +821,7 @@ export default function HomePage() {
               >
                 <div className="inline-flex items-center gap-1.5 sm:gap-2 rounded-full border border-border/70 bg-background/70 backdrop-blur-sm px-2.5 sm:px-3 py-1 text-[10px] sm:text-xs text-muted-foreground mb-4 sm:mb-6">
                   <span className="h-1.5 w-1.5 rounded-full bg-foreground/50 animate-pulse" />
-                  Open source · MIT · 20 components
+                  Open source · MIT · 24 components
                 </div>
               </motion.div>
 
@@ -880,7 +880,7 @@ export default function HomePage() {
                 transition={{ duration: 0.5, delay: 0.3 }}
                 className="text-xs text-muted-foreground/70 mb-4 sm:mb-5"
               >
-                Used by 14+ developers · MIT License · No vendor lock-in
+                MIT License · No vendor lock-in
               </motion.p>
 
               <motion.div
@@ -938,7 +938,7 @@ export default function HomePage() {
                 to="/components"
                 className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors font-medium flex-shrink-0"
               >
-                View all 20 components <ArrowRight className="h-3.5 w-3.5" />
+                View all 24 components <ArrowRight className="h-3.5 w-3.5" />
               </Link>
             </div>
           </motion.div>


### PR DESCRIPTION
This pull request updates the website's content and metadata to reflect an increase in the number of available React PDF components from 20 to 24. It also removes the "Used by 14+ developers" claim from the homepage for a cleaner presentation.

Content and metadata updates for component count:

* Updated all occurrences of "20 components" to "24 components" in homepage banners, feature lists, and call-to-action links within `home.tsx` to match the new component count. [[1]](diffhunk://#diff-ef28dd60a30373789340e7911293ce1245ae16075345f260ce24b1f97800ba22L676-R676) [[2]](diffhunk://#diff-ef28dd60a30373789340e7911293ce1245ae16075345f260ce24b1f97800ba22L729-R729) [[3]](diffhunk://#diff-ef28dd60a30373789340e7911293ce1245ae16075345f260ce24b1f97800ba22L824-R824) [[4]](diffhunk://#diff-ef28dd60a30373789340e7911293ce1245ae16075345f260ce24b1f97800ba22L941-R941)
* Modified the SEO meta description, Open Graph description, and structured data in `index.html` to reflect "24 components" instead of "20 components." [[1]](diffhunk://#diff-f810f76601148fe78122b0b115e9dd6401bc8fc0445f878735965a669ad40fa2L9-R9) [[2]](diffhunk://#diff-f810f76601148fe78122b0b115e9dd6401bc8fc0445f878735965a669ad40fa2L26-R26) [[3]](diffhunk://#diff-f810f76601148fe78122b0b115e9dd6401bc8fc0445f878735965a669ad40fa2L61-R61)

Homepage copy refinement:

* Removed the "Used by 14+ developers" phrase from the homepage subtext for a more streamlined and up-to-date presentation. [[1]](diffhunk://#diff-ef28dd60a30373789340e7911293ce1245ae16075345f260ce24b1f97800ba22L789-R789) [[2]](diffhunk://#diff-ef28dd60a30373789340e7911293ce1245ae16075345f260ce24b1f97800ba22L883-R883)