### PR TITLE
chore(release): switch release tag from alpha to beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Built on [@react-pdf/renderer](https://react-pdf.org/) and inspired by [shadcn/c
 
 ```bash
 # Initialize PDFx in your project
-npx @akii09/pdfx-cli@alpha init
+npx @akii09/pdfx-cli@beta init
 
 # Add components
 npx @akii09/pdfx-cli add heading

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean": "turbo clean && rm -rf node_modules",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "pnpm build && changeset publish --tag alpha",
+    "release": "pnpm build && changeset publish --tag beta",
     "sync:project": "node scripts/sync-to-project.mjs"
   },
   "packageManager": "pnpm@10.29.3",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pdfx/shared",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "description": "Shared types, schemas, and utilities for PDFx",


### PR DESCRIPTION
## Description

Switches the release channel from alpha to beta for the upcoming beta release. This PR prepares the project for beta distribution by updating all npm tag references and fixing a .gitignore issue that was preventing a documentation file from being tracked.

## Related Issue

Closes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📖 Documentation update
- [x] 🔧 Refactor / chore (no functional changes)

## Changes Made

- **README.md**: Updated CLI install command from `@alpha` to `@beta` tag
- **package.json**: Changed release script to publish with `--tag beta` instead of `--tag alpha`
- **packages/shared/package.json**: Removed `-alpha.1` suffix from version (private package doesn't need prerelease tag)
- **.gitignore**: Fixed pattern from `docs` to `/docs` to only ignore root-level docs folder
- **apps/www/src/pages/docs/server-side.tsx**: Added previously ignored server-side rendering documentation page

## How Has This Been Tested?

- [x] Unit tests pass (`pnpm test`)
- [x] Type checks pass (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint`)
- [x] Manually tested locally

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's style guidelines (Biome)
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests that prove my fix or feature works
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation (README, CONTRIBUTING.md, etc.)
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format