### PR TITLE
fix(security): allow connect-src to https://api.github.com in CSP

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -28,7 +28,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob:; connect-src 'self' data: blob:; frame-src 'self' blob:; worker-src 'self' blob:"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob:; connect-src 'self' data: blob: https://api.github.com; frame-src 'self' blob:; worker-src 'self' blob:"
         }
       ]
     }


### PR DESCRIPTION
## Description

Fixes the GitHub Star Banner CSP (Content Security Policy) blocking issue that prevented the banner from fetching star counts in production. The Vercel deployment was blocking API requests to GitHub due to restrictive `connect-src` directive.

## Related Issue

Closes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [x] 🔧 Refactor / chore (no functional changes)

## Changes Made

- **vercel.json**: Added `https://api.github.com` to the `connect-src` Content Security Policy directive
- **github-star-banner.tsx**: Simplified component by removing caching logic and fallback, relying on direct API fetch with graceful degradation

## How Has This Been Tested?

- [x] Unit tests pass (`pnpm test`)
- [x] Type checks pass (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint`)
- [ ] Manually tested locally
- [ ] Deployed to staging/production and verified

## Screenshots (if applicable)

N/A - Backend configuration change only

## Checklist

- [x] My code follows the project's style guidelines (Biome)
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests that prove my fix or feature works
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation (README, CONTRIBUTING.md, etc.)
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format