### PR TITLE
fix: update Content Security Policy to include PostHog assets

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -24,7 +24,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net data:; img-src 'self' data: blob:; connect-src 'self' data: blob: https://api.github.com https://api.npmjs.org https://cdn.jsdelivr.net; frame-src 'self' blob: https://www.youtube-nocookie.com https://vercel.live; worker-src 'self' blob:"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://vercel.live https://us-assets.i.posthog.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net data:; img-src 'self' data: blob:; connect-src 'self' data: blob: https://api.github.com https://api.npmjs.org https://cdn.jsdelivr.net https://us.i.posthog.com https://us-assets.i.posthog.com; frame-src 'self' blob: https://www.youtube-nocookie.com https://vercel.live; worker-src 'self' blob:"
         }
       ]
     }


### PR DESCRIPTION
This pull request updates the Content Security Policy (CSP) in `vercel.json` to allow resources from PostHog domains. This change enables the application to load scripts and connect to endpoints required for PostHog analytics integration.

**Security policy updates:**

* Updated the CSP in `vercel.json` to allow scripts from `https://us-assets.i.posthog.com` and connections to `https://us.i.posthog.com` and `https://us-assets.i.posthog.com`, enabling PostHog analytics support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security headers configuration to enable communication with external service endpoints required for application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->