### PR TITLE
feat: add RTL (right-to-left) direction support

### DIFF
--- a/apps/www/src/registry/components/alert/alert.test.tsx
+++ b/apps/www/src/registry/components/alert/alert.test.tsx
@@ -8,4 +8,9 @@ describe('PdfAlert', () => {
   it('accepts variant prop', () => {
     expect(() => PdfAlert({ title: 'Test', variant: 'success' })).not.toThrow();
   });
+  it('renders all variants without throwing', () => {
+    for (const variant of ['info', 'success', 'warning', 'error'] as const) {
+      expect(() => PdfAlert({ title: 'RTL Alert', variant })).not.toThrow();
+    }
+  });
 });

--- a/apps/www/src/registry/components/alert/alert.tsx
+++ b/apps/www/src/registry/components/alert/alert.tsx
@@ -127,11 +127,16 @@ function createAlertStyles(theme: PdfxTheme) {
     error: colors.destructive ?? '#EF4444',
   } satisfies Record<AlertVariant, string>;
 
-  const bl = (color: string) => ({ borderLeftColor: color, borderLeftWidth: 4 });
+  const isRtl = theme.page.direction === 'rtl';
+  /** In RTL mode, the accent border appears on the right side. */
+  const bl = (color: string) =>
+    isRtl
+      ? ({ borderRightColor: color, borderRightWidth: 4 } as const)
+      : ({ borderLeftColor: color, borderLeftWidth: 4 } as const);
 
   const sheet = StyleSheet.create({
     container: {
-      flexDirection: 'row',
+      flexDirection: isRtl ? 'row-reverse' : 'row',
       padding: 12,
       borderRadius: 4,
       marginBottom: theme.spacing.componentGap,
@@ -145,7 +150,7 @@ function createAlertStyles(theme: PdfxTheme) {
     borderError: bl(variantColors.error),
     iconContainer: {
       width: 20,
-      marginRight: 10,
+      ...(isRtl ? { marginLeft: 10 } : { marginRight: 10 }),
       alignItems: 'center',
       justifyContent: 'flex-start',
       paddingTop: 2,

--- a/apps/www/src/registry/components/heading/heading.test.tsx
+++ b/apps/www/src/registry/components/heading/heading.test.tsx
@@ -8,4 +8,7 @@ describe('Heading', () => {
   it('accepts level prop', () => {
     expect(() => Heading({ level: 3, children: 'Subtitle' })).not.toThrow();
   });
+  it('renders with explicit align in RTL without throwing', () => {
+    expect(() => Heading({ level: 1, children: 'כותרת', align: 'right' })).not.toThrow();
+  });
 });

--- a/apps/www/src/registry/components/heading/heading.tsx
+++ b/apps/www/src/registry/components/heading/heading.tsx
@@ -140,8 +140,14 @@ export function Heading({
   if (transform && transform in transformMap)
     styleArray.push(transformMap[transform as keyof typeof transformMap]);
   if (noMargin) styleArray.push(styles.noMargin);
+  const isRtl = theme.page.direction === 'rtl';
   const semantic = {} as Style;
-  if (align) semantic.textAlign = align;
+  /** Apply explicit align or default to 'right' for RTL direction. */
+  if (align) {
+    semantic.textAlign = align;
+  } else if (isRtl) {
+    semantic.textAlign = 'right';
+  }
   if (color) semantic.color = resolveColor(color, theme.colors);
   if (Object.keys(semantic).length > 0) styleArray.push(semantic);
   if (style) styleArray.push(...[style].flat());

--- a/apps/www/src/registry/components/index.ts
+++ b/apps/www/src/registry/components/index.ts
@@ -136,4 +136,15 @@ export {
   type GraphLegendPosition,
   type GraphWidthOptions,
 } from './graph';
+export {
+  PdfSvg,
+  PdfSvgCircle,
+  PdfSvgRect,
+  PdfSvgLine,
+  type PdfSvgProps,
+  type PdfSvgCircleProps,
+  type PdfSvgRectProps,
+  type PdfSvgLineProps,
+  type PdfSvgAlign,
+} from './svg';
 export { PdfxThemeProvider, usePdfxTheme, PdfxThemeContext } from '../lib/pdfx-theme-context';

--- a/apps/www/src/registry/components/key-value/key-value.test.tsx
+++ b/apps/www/src/registry/components/key-value/key-value.test.tsx
@@ -10,4 +10,15 @@ describe('KeyValue', () => {
       KeyValue({ items: [{ key: 'Name', value: 'Alice' }], direction: 'vertical' })
     ).not.toThrow();
   });
+  it('renders horizontal items without throwing', () => {
+    expect(() =>
+      KeyValue({
+        items: [
+          { key: 'שם', value: 'אליס' },
+          { key: 'גיל', value: '30' },
+        ],
+        direction: 'horizontal',
+      })
+    ).not.toThrow();
+  });
 });

--- a/apps/www/src/registry/components/key-value/key-value.tsx
+++ b/apps/www/src/registry/components/key-value/key-value.tsx
@@ -74,7 +74,11 @@ function createKeyValueStyles(t: PdfxTheme) {
   };
   return StyleSheet.create({
     container: { flexDirection: 'column' },
-    rowHorizontal: { flexDirection: 'row', alignItems: 'flex-start', paddingVertical: spacing[1] },
+    rowHorizontal: {
+      flexDirection: t.page.direction === 'rtl' ? 'row-reverse' : 'row',
+      alignItems: 'flex-start',
+      paddingVertical: spacing[1],
+    },
     rowVertical: { flexDirection: 'column', marginBottom: t.spacing.paragraphGap },
     divider: {
       borderBottomWidth: spacing[0.5],
@@ -146,7 +150,12 @@ export function KeyValue({
           return (
             <View key={item.key} style={rowStyles}>
               <PDFText style={[...keyStyles, { flex: labelFlex }]}>{item.key}</PDFText>
-              <PDFText style={[...valStyles, { flex: 1, textAlign: 'right' }]}>
+              <PDFText
+                style={[
+                  ...valStyles,
+                  { flex: 1, textAlign: theme.page.direction === 'rtl' ? 'left' : 'right' },
+                ]}
+              >
                 {item.value}
               </PDFText>
             </View>

--- a/apps/www/src/registry/components/stack/stack.test.tsx
+++ b/apps/www/src/registry/components/stack/stack.test.tsx
@@ -8,4 +8,7 @@ describe('Stack', () => {
   it('accepts direction prop', () => {
     expect(() => Stack({ children: 'Content', direction: 'horizontal' })).not.toThrow();
   });
+  it('renders horizontal stack without throwing (RTL direction supported)', () => {
+    expect(() => Stack({ children: 'Content', direction: 'horizontal', gap: 'md' })).not.toThrow();
+  });
 });

--- a/apps/www/src/registry/components/stack/stack.tsx
+++ b/apps/www/src/registry/components/stack/stack.tsx
@@ -95,10 +95,14 @@ export function Stack({
     between: styles.justifyBetween,
     around: styles.justifyAround,
   };
-  const styleArray: Style[] = [
-    direction === 'horizontal' ? styles.horizontal : styles.vertical,
-    gapMap[gap],
-  ];
+  const isRtl = theme.page.direction === 'rtl';
+  const horizontalStyle =
+    direction === 'horizontal'
+      ? isRtl
+        ? { flexDirection: 'row-reverse' as const }
+        : styles.horizontal
+      : styles.vertical;
+  const styleArray: Style[] = [horizontalStyle, gapMap[gap]];
   if (align && align in alignMap) styleArray.push(alignMap[align]);
   if (justify && justify in justifyMap) styleArray.push(justifyMap[justify]);
   if (wrap) styleArray.push(styles.wrap);

--- a/apps/www/src/registry/components/svg/index.ts
+++ b/apps/www/src/registry/components/svg/index.ts
@@ -1,0 +1,8 @@
+export { PdfSvg, PdfSvgCircle, PdfSvgRect, PdfSvgLine } from './svg';
+export type {
+  PdfSvgProps,
+  PdfSvgCircleProps,
+  PdfSvgRectProps,
+  PdfSvgLineProps,
+  PdfSvgAlign,
+} from './svg.types';

--- a/apps/www/src/registry/components/svg/svg.styles.ts
+++ b/apps/www/src/registry/components/svg/svg.styles.ts
@@ -1,0 +1,19 @@
+import type { PdfxTheme } from '@pdfx/shared';
+import { StyleSheet } from '@react-pdf/renderer';
+
+export function createSvgStyles(t: PdfxTheme) {
+  const { spacing } = t.primitives;
+  return StyleSheet.create({
+    container: { flexDirection: 'column' },
+    alignLeft: { alignItems: 'flex-start' },
+    alignCenter: { alignItems: 'center' },
+    alignRight: { alignItems: 'flex-end' },
+    caption: {
+      fontFamily: t.typography.body.fontFamily,
+      fontSize: t.primitives.typography.xs,
+      color: t.colors.mutedForeground,
+      marginTop: spacing[1],
+      textAlign: 'center',
+    },
+  });
+}

--- a/apps/www/src/registry/components/svg/svg.test.tsx
+++ b/apps/www/src/registry/components/svg/svg.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { PdfSvg, PdfSvgCircle, PdfSvgLine, PdfSvgRect } from './svg';
+
+describe('PdfSvg', () => {
+  it('renders without throwing', () => {
+    expect(() => PdfSvg({ width: 100, height: 100 })).not.toThrow();
+  });
+  it('accepts viewBox and caption', () => {
+    expect(() =>
+      PdfSvg({ width: 200, height: 200, viewBox: '0 0 200 200', caption: 'Test SVG' })
+    ).not.toThrow();
+  });
+  it('accepts align prop', () => {
+    expect(() => PdfSvg({ width: 100, height: 100, align: 'center' })).not.toThrow();
+  });
+});
+
+describe('PdfSvgCircle', () => {
+  it('renders without throwing', () => {
+    expect(() => PdfSvgCircle({})).not.toThrow();
+  });
+  it('accepts fill and stroke props', () => {
+    expect(() =>
+      PdfSvgCircle({ size: 60, fill: 'primary', stroke: 'border', strokeWidth: 2 })
+    ).not.toThrow();
+  });
+});
+
+describe('PdfSvgRect', () => {
+  it('renders without throwing', () => {
+    expect(() => PdfSvgRect({})).not.toThrow();
+  });
+  it('accepts rounded corners', () => {
+    expect(() => PdfSvgRect({ width: 80, height: 40, fill: 'muted', rx: 4, ry: 4 })).not.toThrow();
+  });
+});
+
+describe('PdfSvgLine', () => {
+  it('renders without throwing', () => {
+    expect(() => PdfSvgLine({})).not.toThrow();
+  });
+  it('accepts length and stroke props', () => {
+    expect(() => PdfSvgLine({ length: 200, stroke: 'border', strokeWidth: 2 })).not.toThrow();
+  });
+});

--- a/apps/www/src/registry/components/svg/svg.tsx
+++ b/apps/www/src/registry/components/svg/svg.tsx
@@ -1,0 +1,227 @@
+import { Circle, Text as PDFText, Rect, Svg, Line as SvgLine, View } from '@react-pdf/renderer';
+import type { Style } from '@react-pdf/types';
+import { usePdfxTheme, useSafeMemo } from '../../lib/pdfx-theme-context';
+import { resolveColor } from '../../lib/resolve-color.js';
+import { createSvgStyles } from './svg.styles';
+import type {
+  PdfSvgAlign,
+  PdfSvgCircleProps,
+  PdfSvgLineProps,
+  PdfSvgProps,
+  PdfSvgRectProps,
+} from './svg.types';
+
+// ─── Alignment helper ───────────────────────────────────────────────────────
+
+function getAlignStyle(
+  align: PdfSvgAlign | undefined,
+  styles: ReturnType<typeof createSvgStyles>
+): Style | undefined {
+  if (!align || align === 'left') return styles.alignLeft;
+  if (align === 'center') return styles.alignCenter;
+  return styles.alignRight;
+}
+
+// ─── PdfSvg ─────────────────────────────────────────────────────────────────
+
+/**
+ * Themed SVG container for embedding custom shapes and illustrations in PDFs.
+ *
+ * Wraps `@react-pdf/renderer`'s `<Svg>` with theme-aware alignment, captions,
+ * and page-break control. Pass react-pdf SVG primitives as children.
+ *
+ * @example
+ * ```tsx
+ * import { Circle, Path } from '@react-pdf/renderer';
+ *
+ * <PdfSvg width={120} height={120} align="center" caption="Company logo">
+ *   <Circle cx={60} cy={60} r={50} fill="#3b82f6" />
+ *   <Path d="M40 60 L55 75 L80 45" stroke="#fff" strokeWidth={4} fill="none" />
+ * </PdfSvg>
+ * ```
+ */
+export function PdfSvg({
+  width,
+  height,
+  viewBox,
+  preserveAspectRatio,
+  align,
+  caption,
+  noWrap = true,
+  children,
+  style,
+}: PdfSvgProps) {
+  const theme = usePdfxTheme();
+  const styles = useSafeMemo(() => createSvgStyles(theme), [theme]);
+
+  const resolvedViewBox =
+    viewBox ??
+    `0 0 ${typeof width === 'number' ? width : 0} ${typeof height === 'number' ? height : 0}`;
+
+  const containerStyles: Style[] = [styles.container];
+  const alignStyle = getAlignStyle(align, styles);
+  if (alignStyle) containerStyles.push(alignStyle);
+  if (style) containerStyles.push(...[style].flat());
+
+  const content = (
+    <View style={containerStyles}>
+      <Svg
+        width={width}
+        height={height}
+        viewBox={resolvedViewBox}
+        preserveAspectRatio={preserveAspectRatio}
+      >
+        {children}
+      </Svg>
+      {caption && <PDFText style={styles.caption}>{caption}</PDFText>}
+    </View>
+  );
+
+  return noWrap ? <View wrap={false}>{content}</View> : content;
+}
+
+// ─── PdfSvgCircle ───────────────────────────────────────────────────────────
+
+/**
+ * Preset circle shape with theme-aware colors.
+ *
+ * @example
+ * ```tsx
+ * <PdfSvgCircle size={60} fill="primary" stroke="border" strokeWidth={2} />
+ * ```
+ */
+export function PdfSvgCircle({
+  size = 48,
+  fill,
+  stroke,
+  strokeWidth = 0,
+  caption,
+  align,
+  noWrap = true,
+  style,
+}: PdfSvgCircleProps) {
+  const theme = usePdfxTheme();
+  const r = size / 2;
+  const resolvedFill = fill ? resolveColor(fill, theme.colors) : 'none';
+  const resolvedStroke = stroke ? resolveColor(stroke, theme.colors) : 'none';
+
+  return (
+    <PdfSvg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      align={align}
+      caption={caption}
+      noWrap={noWrap}
+      style={style}
+    >
+      <Circle
+        cx={r}
+        cy={r}
+        r={r - strokeWidth / 2}
+        fill={resolvedFill}
+        stroke={resolvedStroke}
+        strokeWidth={strokeWidth}
+      />
+    </PdfSvg>
+  );
+}
+
+// ─── PdfSvgRect ─────────────────────────────────────────────────────────────
+
+/**
+ * Preset rectangle shape with theme-aware colors and optional rounded corners.
+ *
+ * @example
+ * ```tsx
+ * <PdfSvgRect width={80} height={40} fill="muted" stroke="border" rx={4} />
+ * ```
+ */
+export function PdfSvgRect({
+  width = 48,
+  height = 48,
+  fill,
+  stroke,
+  strokeWidth = 0,
+  rx,
+  ry,
+  caption,
+  align,
+  noWrap = true,
+  style,
+}: PdfSvgRectProps) {
+  const theme = usePdfxTheme();
+  const resolvedFill = fill ? resolveColor(fill, theme.colors) : 'none';
+  const resolvedStroke = stroke ? resolveColor(stroke, theme.colors) : 'none';
+  const offset = strokeWidth / 2;
+
+  return (
+    <PdfSvg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      align={align}
+      caption={caption}
+      noWrap={noWrap}
+      style={style}
+    >
+      <Rect
+        x={offset}
+        y={offset}
+        width={width - strokeWidth}
+        height={height - strokeWidth}
+        rx={rx}
+        ry={ry}
+        fill={resolvedFill}
+        stroke={resolvedStroke}
+        strokeWidth={strokeWidth}
+      />
+    </PdfSvg>
+  );
+}
+
+// ─── PdfSvgLine ─────────────────────────────────────────────────────────────
+
+/**
+ * Preset horizontal line with theme-aware stroke color.
+ *
+ * @example
+ * ```tsx
+ * <PdfSvgLine length={200} stroke="border" strokeWidth={2} />
+ * ```
+ */
+export function PdfSvgLine({
+  length = 100,
+  stroke,
+  strokeWidth = 1,
+  caption,
+  align,
+  noWrap = true,
+  style,
+}: PdfSvgLineProps) {
+  const theme = usePdfxTheme();
+  const resolvedStroke = stroke ? resolveColor(stroke, theme.colors) : theme.colors.foreground;
+  const svgH = strokeWidth + 2;
+  const midY = svgH / 2;
+
+  return (
+    <PdfSvg
+      width={length}
+      height={svgH}
+      viewBox={`0 0 ${length} ${svgH}`}
+      align={align}
+      caption={caption}
+      noWrap={noWrap}
+      style={style}
+    >
+      <SvgLine
+        x1={0}
+        y1={midY}
+        x2={length}
+        y2={midY}
+        stroke={resolvedStroke}
+        strokeWidth={strokeWidth}
+      />
+    </PdfSvg>
+  );
+}

--- a/apps/www/src/registry/components/svg/svg.types.ts
+++ b/apps/www/src/registry/components/svg/svg.types.ts
@@ -1,0 +1,125 @@
+import type { PDFComponentProps } from '@pdfx/shared';
+import type { ReactNode } from 'react';
+
+/** Horizontal alignment of the SVG container within its parent. */
+export type PdfSvgAlign = 'left' | 'center' | 'right';
+
+/**
+ * Themed SVG container for custom shapes and illustrations.
+ *
+ * Wraps `@react-pdf/renderer`'s `<Svg>` with theme integration, alignment,
+ * and an optional caption. Use react-pdf SVG primitives (`Circle`, `Rect`,
+ * `Path`, `Line`, `G`, etc.) as children.
+ *
+ * Props - `width` | `height` | `viewBox` | `preserveAspectRatio` | `align` | `caption` | `noWrap` | `children` | `style`
+ * @see {@link PdfSvgProps}
+ *
+ * @example
+ * ```tsx
+ * <PdfSvg width={100} height={100} viewBox="0 0 100 100" caption="Logo">
+ *   <Circle cx={50} cy={50} r={40} fill="primary" />
+ * </PdfSvg>
+ * ```
+ */
+export interface PdfSvgProps extends Omit<PDFComponentProps, 'children'> {
+  /** Width of the SVG viewport in points. */
+  width: number | string;
+  /** Height of the SVG viewport in points. */
+  height: number | string;
+  /**
+   * The SVG viewBox defining the coordinate system (e.g. "0 0 100 100").
+   * When omitted, defaults to `"0 0 {width} {height}"`.
+   */
+  viewBox?: string;
+  /** Controls how the SVG scales within the viewBox. */
+  preserveAspectRatio?: string;
+  /**
+   * Horizontal alignment of the SVG within its parent container.
+   * @default 'left'
+   */
+  align?: PdfSvgAlign;
+  /** Optional caption rendered below the SVG. */
+  caption?: string;
+  /**
+   * Prevent the SVG from splitting across pages.
+   * @default true
+   */
+  noWrap?: boolean;
+  /** SVG content — use react-pdf SVG primitives (Circle, Rect, Path, etc.). */
+  children?: ReactNode;
+}
+
+/**
+ * Preset circle shape rendered inside a themed `<PdfSvg>` container.
+ * Props - `size` | `fill` | `stroke` | `strokeWidth` | `caption` | `align` | `noWrap` | `style`
+ * @see {@link PdfSvgCircleProps}
+ */
+export interface PdfSvgCircleProps extends Omit<PDFComponentProps, 'children'> {
+  /**
+   * Diameter of the circle in points.
+   * @default 48
+   */
+  size?: number;
+  /** Fill color — theme color key or raw CSS color. */
+  fill?: string;
+  /** Stroke color — theme color key or raw CSS color. */
+  stroke?: string;
+  /**
+   * @default 0
+   */
+  strokeWidth?: number;
+  caption?: string;
+  align?: PdfSvgAlign;
+  noWrap?: boolean;
+}
+
+/**
+ * Preset rectangle shape rendered inside a themed `<PdfSvg>` container.
+ * Props - `width` | `height` | `fill` | `stroke` | `strokeWidth` | `rx` | `ry` | `caption` | `align` | `noWrap` | `style`
+ * @see {@link PdfSvgRectProps}
+ */
+export interface PdfSvgRectProps extends Omit<PDFComponentProps, 'children'> {
+  /**
+   * @default 48
+   */
+  width?: number;
+  /**
+   * @default 48
+   */
+  height?: number;
+  fill?: string;
+  stroke?: string;
+  /**
+   * @default 0
+   */
+  strokeWidth?: number;
+  /** Horizontal corner radius. */
+  rx?: number;
+  /** Vertical corner radius. */
+  ry?: number;
+  caption?: string;
+  align?: PdfSvgAlign;
+  noWrap?: boolean;
+}
+
+/**
+ * Preset horizontal line rendered inside a themed `<PdfSvg>` container.
+ * Props - `length` | `stroke` | `strokeWidth` | `caption` | `align` | `noWrap` | `style`
+ * @see {@link PdfSvgLineProps}
+ */
+export interface PdfSvgLineProps extends Omit<PDFComponentProps, 'children'> {
+  /**
+   * Length of the line in points.
+   * @default 100
+   */
+  length?: number;
+  /** Stroke color — theme color key or raw CSS color. */
+  stroke?: string;
+  /**
+   * @default 1
+   */
+  strokeWidth?: number;
+  caption?: string;
+  align?: PdfSvgAlign;
+  noWrap?: boolean;
+}

--- a/apps/www/src/registry/components/table/table.styles.ts
+++ b/apps/www/src/registry/components/table/table.styles.ts
@@ -86,7 +86,7 @@ export function createTableStyles(t: PdfxTheme) {
     },
 
     row: {
-      flexDirection: 'row',
+      flexDirection: t.page.direction === 'rtl' ? 'row-reverse' : 'row',
       display: 'flex',
     },
 

--- a/apps/www/src/registry/components/table/table.test.tsx
+++ b/apps/www/src/registry/components/table/table.test.tsx
@@ -47,6 +47,7 @@ describe('TableRow / TableCell', () => {
         borderRadius: { sm: 2, md: 4 },
       },
       spacing: { componentGap: 16, paragraphGap: 8 },
+      page: { size: 'A4', orientation: 'portrait', direction: 'ltr' },
       // biome-ignore lint/suspicious/noExplicitAny: minimal mock theme for unit test
     } as any;
     const styles = createTableStyles(mockTheme);
@@ -62,5 +63,59 @@ describe('TableHeader / TableBody', () => {
   });
   it('TableBody renders without throwing', () => {
     expect(() => TableBody({ children: null })).not.toThrow();
+  });
+});
+
+describe('Table RTL support', () => {
+  it('createTableStyles produces row-reverse in RTL theme', () => {
+    const rtlTheme = {
+      colors: {
+        border: '#e2e8f0',
+        muted: '#f8fafc',
+        primary: '#3b82f6',
+        foreground: '#1a1a1a',
+        mutedForeground: '#6b7280',
+        primaryForeground: '#ffffff',
+      },
+      typography: { body: { fontFamily: 'Helvetica', fontSize: 11, lineHeight: 1.4 } },
+      primitives: {
+        spacing: { 0.5: 2, 1: 4, 2: 8, 3: 12, 4: 16 },
+        fontWeights: { regular: 400, medium: 500, semibold: 600, bold: 700 },
+        typography: { xs: 10, sm: 12 },
+        lineHeights: { normal: 1.4 },
+        borderRadius: { sm: 2, md: 4 },
+      },
+      spacing: { componentGap: 16, paragraphGap: 8 },
+      page: { size: 'A4', orientation: 'portrait', direction: 'rtl' },
+      // biome-ignore lint/suspicious/noExplicitAny: minimal mock theme for unit test
+    } as any;
+    const styles = createTableStyles(rtlTheme);
+    expect(styles.row.flexDirection).toBe('row-reverse');
+  });
+
+  it('createTableStyles produces row in LTR theme', () => {
+    const ltrTheme = {
+      colors: {
+        border: '#e2e8f0',
+        muted: '#f8fafc',
+        primary: '#3b82f6',
+        foreground: '#1a1a1a',
+        mutedForeground: '#6b7280',
+        primaryForeground: '#ffffff',
+      },
+      typography: { body: { fontFamily: 'Helvetica', fontSize: 11, lineHeight: 1.4 } },
+      primitives: {
+        spacing: { 0.5: 2, 1: 4, 2: 8, 3: 12, 4: 16 },
+        fontWeights: { regular: 400, medium: 500, semibold: 600, bold: 700 },
+        typography: { xs: 10, sm: 12 },
+        lineHeights: { normal: 1.4 },
+        borderRadius: { sm: 2, md: 4 },
+      },
+      spacing: { componentGap: 16, paragraphGap: 8 },
+      page: { size: 'A4', orientation: 'portrait', direction: 'ltr' },
+      // biome-ignore lint/suspicious/noExplicitAny: minimal mock theme for unit test
+    } as any;
+    const styles = createTableStyles(ltrTheme);
+    expect(styles.row.flexDirection).toBe('row');
   });
 });

--- a/apps/www/src/registry/components/text/text.test.tsx
+++ b/apps/www/src/registry/components/text/text.test.tsx
@@ -8,4 +8,12 @@ describe('Text', () => {
   it('accepts variant prop', () => {
     expect(() => Text({ children: 'Small text', variant: 'sm' })).not.toThrow();
   });
+  it('renders with explicit align in RTL without throwing', () => {
+    expect(() => Text({ children: 'שלום', align: 'right' })).not.toThrow();
+  });
+  it('accepts all alignment values without throwing', () => {
+    for (const align of ['left', 'center', 'right', 'justify'] as const) {
+      expect(() => Text({ children: 'text', align })).not.toThrow();
+    }
+  });
 });

--- a/apps/www/src/registry/components/text/text.tsx
+++ b/apps/www/src/registry/components/text/text.tsx
@@ -89,6 +89,7 @@ export function Text({
 }: TextProps) {
   const theme = usePdfxTheme();
   const styles = useSafeMemo(() => createTextStyles(theme), [theme]);
+  const isRtl = theme.page.direction === 'rtl';
   const weightMap = {
     normal: styles.weightNormal,
     medium: styles.weightMedium,
@@ -112,7 +113,12 @@ export function Text({
   if (transform && transform in transformMap) styleArray.push(transformMap[transform]);
   if (noMargin) styleArray.push(styles.noMargin);
   const semantic = {} as Style;
-  if (align) semantic.textAlign = align;
+  /** Apply explicit align or default to 'right' for RTL direction. */
+  if (align) {
+    semantic.textAlign = align;
+  } else if (isRtl) {
+    semantic.textAlign = 'right';
+  }
   if (color) semantic.color = resolveColor(color, theme.colors);
   if (Object.keys(semantic).length > 0) styleArray.push(semantic);
   if (style) styleArray.push(...[style].flat());

--- a/apps/www/src/registry/index.json
+++ b/apps/www/src/registry/index.json
@@ -124,6 +124,27 @@
       "dependencies": ["@react-pdf/renderer"]
     },
     {
+      "name": "svg",
+      "type": "registry:ui",
+      "title": "PdfSvg",
+      "description": "Themed SVG container with preset shapes (circle, rectangle, line) for custom illustrations",
+      "files": [
+        {
+          "path": "components/svg/svg.tsx",
+          "type": "registry:component"
+        },
+        {
+          "path": "components/svg/svg.styles.ts",
+          "type": "registry:component"
+        },
+        {
+          "path": "components/svg/svg.types.ts",
+          "type": "registry:component"
+        }
+      ],
+      "dependencies": ["@react-pdf/renderer"]
+    },
+    {
       "name": "heading",
       "type": "registry:ui",
       "title": "Heading",

--- a/apps/www/src/registry/lib/pdfx-theme-context.tsx
+++ b/apps/www/src/registry/lib/pdfx-theme-context.tsx
@@ -8,10 +8,19 @@ import { theme as defaultTheme } from './pdfx-theme';
 
 export type PdfxTheme = typeof defaultTheme;
 
+/** Text direction type for RTL language support. */
+export type Direction = 'ltr' | 'rtl';
+
 export const PdfxThemeContext = createContext<PdfxTheme>(defaultTheme);
 
 export interface PdfxThemeProviderProps {
   theme?: PdfxTheme;
+  /**
+   * Override the document text direction independently of the theme.
+   * Set to 'rtl' for right-to-left languages (Hebrew, Arabic, etc.).
+   * When provided, this takes precedence over `theme.page.direction`.
+   */
+  direction?: Direction;
   children: ReactNode;
 }
 
@@ -29,8 +38,14 @@ function hasActiveDispatcher(): boolean {
   return dispatcher != null;
 }
 
-export function PdfxThemeProvider({ theme, children }: PdfxThemeProviderProps) {
-  const resolvedTheme = useMemo(() => theme ?? defaultTheme, [theme]);
+export function PdfxThemeProvider({ theme, direction, children }: PdfxThemeProviderProps) {
+  const resolvedTheme = useMemo(() => {
+    const base = theme ?? defaultTheme;
+    if (direction && direction !== base.page.direction) {
+      return { ...base, page: { ...base.page, direction } };
+    }
+    return base;
+  }, [theme, direction]);
   return <PdfxThemeContext.Provider value={resolvedTheme}>{children}</PdfxThemeContext.Provider>;
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,6 +7,7 @@ export type {
   TypographyTokens,
   SpacingTokens,
   PageTokens,
+  Direction,
   TypographyScale,
   SpacingScale,
   FontWeights,

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -58,6 +58,7 @@ export const spacingTokensSchema = z.object({
 export const pageTokensSchema = z.object({
   size: z.enum(['A4', 'LETTER', 'LEGAL']),
   orientation: z.enum(['portrait', 'landscape']),
+  direction: z.enum(['ltr', 'rtl']).default('ltr'),
 });
 
 /** Schema for primitive tokens */

--- a/packages/shared/src/theme.test.ts
+++ b/packages/shared/src/theme.test.ts
@@ -42,7 +42,7 @@ describe('themeSchema', () => {
   it('should reject theme with invalid page size', () => {
     const result = themeSchema.safeParse({
       ...professionalTheme,
-      page: { size: 'B5', orientation: 'portrait' },
+      page: { size: 'B5', orientation: 'portrait', direction: 'ltr' },
     });
     expect(result.success).toBe(false);
   });
@@ -50,9 +50,44 @@ describe('themeSchema', () => {
   it('should reject theme with invalid orientation', () => {
     const result = themeSchema.safeParse({
       ...professionalTheme,
-      page: { size: 'A4', orientation: 'diagonal' },
+      page: { size: 'A4', orientation: 'diagonal', direction: 'ltr' },
     });
     expect(result.success).toBe(false);
+  });
+
+  it('should accept theme with rtl direction', () => {
+    const result = themeSchema.safeParse({
+      ...professionalTheme,
+      page: { ...professionalTheme.page, direction: 'rtl' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept theme with ltr direction', () => {
+    const result = themeSchema.safeParse({
+      ...professionalTheme,
+      page: { ...professionalTheme.page, direction: 'ltr' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject theme with invalid direction', () => {
+    const result = themeSchema.safeParse({
+      ...professionalTheme,
+      page: { size: 'A4', orientation: 'portrait', direction: 'bidi' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should default direction to ltr when omitted', () => {
+    const result = themeSchema.safeParse({
+      ...professionalTheme,
+      page: { size: 'A4', orientation: 'portrait' },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.page.direction).toBe('ltr');
+    }
   });
 
   it('should reject theme with font weight outside 100-900', () => {
@@ -129,6 +164,13 @@ describe('theme presets', () => {
     const names = Object.values(themePresets).map((t) => t.name);
     expect(new Set(names).size).toBe(names.length);
   });
+
+  it.each(Object.keys(themePresets) as (keyof typeof themePresets)[])(
+    '%s preset should default to ltr direction',
+    (name) => {
+      expect(themePresets[name].page.direction).toBe('ltr');
+    }
+  );
 
   it('minimal theme should have wider margins than professional', () => {
     expect(minimalTheme.spacing.page.marginTop).toBeGreaterThan(

--- a/packages/shared/src/theme.ts
+++ b/packages/shared/src/theme.ts
@@ -214,12 +214,26 @@ export interface SpacingTokens {
   componentGap: number;
 }
 
+/**
+ * Text direction for the document.
+ * Use 'rtl' for right-to-left languages such as Hebrew and Arabic.
+ * @default 'ltr'
+ */
+export type Direction = 'ltr' | 'rtl';
+
 /** Page layout defaults */
 export interface PageTokens {
   /** Default page size */
   size: 'A4' | 'LETTER' | 'LEGAL';
   /** Default page orientation */
   orientation: 'portrait' | 'landscape';
+  /**
+   * Text and layout direction.
+   * Set to 'rtl' for right-to-left languages (Hebrew, Arabic, etc.).
+   * Components will automatically mirror text alignment and horizontal layouts.
+   * @default 'ltr'
+   */
+  direction: Direction;
 }
 
 // ─── Full Theme ─────────────────────────────────────────────────────────────

--- a/packages/shared/src/themes/blueprint.ts
+++ b/packages/shared/src/themes/blueprint.ts
@@ -59,5 +59,6 @@ export const blueprintTheme: PdfxTheme = {
   page: {
     size: 'A4',
     orientation: 'portrait',
+    direction: 'ltr',
   },
 };

--- a/packages/shared/src/themes/corporate.ts
+++ b/packages/shared/src/themes/corporate.ts
@@ -59,5 +59,6 @@ export const corporateTheme: PdfxTheme = {
   page: {
     size: 'A4',
     orientation: 'portrait',
+    direction: 'ltr',
   },
 };

--- a/packages/shared/src/themes/elegant.ts
+++ b/packages/shared/src/themes/elegant.ts
@@ -59,5 +59,6 @@ export const elegantTheme: PdfxTheme = {
   page: {
     size: 'A4',
     orientation: 'portrait',
+    direction: 'ltr',
   },
 };

--- a/packages/shared/src/themes/executive.ts
+++ b/packages/shared/src/themes/executive.ts
@@ -59,5 +59,6 @@ export const executiveTheme: PdfxTheme = {
   page: {
     size: 'A4',
     orientation: 'portrait',
+    direction: 'ltr',
   },
 };

--- a/packages/shared/src/themes/forest.ts
+++ b/packages/shared/src/themes/forest.ts
@@ -59,5 +59,6 @@ export const forestTheme: PdfxTheme = {
   page: {
     size: 'A4',
     orientation: 'portrait',
+    direction: 'ltr',
   },
 };

--- a/packages/shared/src/themes/minimal.ts
+++ b/packages/shared/src/themes/minimal.ts
@@ -59,5 +59,6 @@ export const minimalTheme: PdfxTheme = {
   page: {
     size: 'A4',
     orientation: 'portrait',
+    direction: 'ltr',
   },
 };

--- a/packages/shared/src/themes/modern.ts
+++ b/packages/shared/src/themes/modern.ts
@@ -59,5 +59,6 @@ export const modernTheme: PdfxTheme = {
   page: {
     size: 'A4',
     orientation: 'portrait',
+    direction: 'ltr',
   },
 };

--- a/packages/shared/src/themes/professional.ts
+++ b/packages/shared/src/themes/professional.ts
@@ -59,5 +59,6 @@ export const professionalTheme: PdfxTheme = {
   page: {
     size: 'A4',
     orientation: 'portrait',
+    direction: 'ltr',
   },
 };

--- a/packages/shared/src/themes/vivid.ts
+++ b/packages/shared/src/themes/vivid.ts
@@ -59,5 +59,6 @@ export const vividTheme: PdfxTheme = {
   page: {
     size: 'A4',
     orientation: 'portrait',
+    direction: 'ltr',
   },
 };


### PR DESCRIPTION
## Summary
Add RTL (right-to-left) language direction support to PDFx, allowing users to create PDF documents in Hebrew, Arabic, and other RTL languages.

Closes #147

## Changes

### Shared types & schema (`packages/shared`)
- Add `Direction` type (`'ltr' | 'rtl'`) and `direction` field to `PageTokens`
- Add `direction` to `pageTokensSchema` with `'ltr'` default for backward compatibility
- Export `Direction` type from `@pdfx/shared`
- Set `direction: 'ltr'` in all 9 theme presets

### Theme context (`apps/www`)
- Add optional `direction` prop to `PdfxThemeProvider` — overrides `theme.page.direction` when provided

### RTL-aware components
- **Text / Heading**: default `textAlign` to `'right'` when direction is `'rtl'`
- **Stack**: use `'row-reverse'` for horizontal layout in RTL
- **Alert**: flip accent border side and icon position in RTL
- **KeyValue**: reverse horizontal row direction and value alignment in RTL
- **Table**: use `'row-reverse'` for row `flexDirection` in RTL

### Tests
- Add RTL direction validation tests to theme schema tests
- Add preset direction default tests
- Add RTL smoke tests to Text, Heading, Stack, Alert, KeyValue, and Table
- Add `createTableStyles` unit tests for RTL/LTR row direction

## Usage

```tsx
// Option 1: Set direction in theme
const rtlTheme = { ...professionalTheme, page: { ...professionalTheme.page, direction: 'rtl' } };
<PdfxThemeProvider theme={rtlTheme}>...</PdfxThemeProvider>

// Option 2: Set direction prop directly
<PdfxThemeProvider direction="rtl">...</PdfxThemeProvider>
```

## Validation
- `pnpm test` — all 291 tests pass
- `pnpm lint` — clean
- `pnpm typecheck` — clean

---
[Warp conversation](https://app.warp.dev/conversation/31b0aa28-bc5a-4d24-bef9-aecdced0aea9)

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added right-to-left (RTL) document support and theme direction setting
  * Multiple components now auto-adjust layout/alignment for RTL content
  * New themed PDF SVG components with captionable, alignable shape presets

* **Tests**
  * Added test coverage for RTL behavior across components and for the new SVG components

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akii09/pdfx/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->