### PR TITLE
feat: add server-side PDF generation guide and update init command ou…

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -64,6 +64,37 @@ PDFx comes with first-class AI Agent integration via MCP (Model Context Protocol
 npx pdfx-cli@latest mcp init --client cursor
 ```
 
+## Server-side / Node.js
+
+PDFx components run in Node.js just as well as in the browser, so you can generate and save a
+PDF to a file on the server. `@react-pdf/renderer` exposes `renderToFile`, `renderToBuffer`, and
+`renderToStream` for this:
+
+```tsx
+import { renderToFile } from '@react-pdf/renderer';
+import { Document, Page } from '@react-pdf/renderer';
+import { Heading } from './src/components/pdfx/heading/pdfx-heading';
+import { Text } from './src/components/pdfx/text/pdfx-text';
+
+const doc = (
+  <Document>
+    <Page size="A4" style={{ padding: 40 }}>
+      <Heading level={1}>Monthly Report</Heading>
+      <Text>Generated server-side with PDFx.</Text>
+    </Page>
+  </Document>
+);
+
+// Write straight to disk:
+await renderToFile(doc, './output.pdf');
+
+// …or get a Buffer to return from an API route / attach to an email:
+// const buffer = await renderToBuffer(doc);
+```
+
+See the full guide (Express, Next.js API routes, fonts) at
+[pdfx.akashpise.dev/docs/server-side](https://pdfx.akashpise.dev/docs/server-side).
+
 ## Documentation
 
 Full documentation, real-time PDF previews, and block gallery available at [pdfx.akashpise.dev](https://pdfx.akashpise.dev).

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -4,7 +4,7 @@ import { type ThemePresetName, configSchema, themePresets } from '@pdfx/shared';
 import chalk from 'chalk';
 import ora from 'ora';
 import prompts from 'prompts';
-import { DEFAULTS } from '../constants.js';
+import { DEFAULTS, DOCS } from '../constants.js';
 import { ensureDir } from '../utils/file-system.js';
 import { generateThemeContextFile, generateThemeFile } from '../utils/generate-theme.js';
 import { ensureReactPdfRenderer } from '../utils/install-dependencies.js';
@@ -215,7 +215,9 @@ export async function init(options: InitOptions = {}) {
     console.log(chalk.cyan('  npx pdfx-cli@latest block add invoice-classic'));
     console.log(chalk.dim(`\n  Components: ${path.resolve(process.cwd(), answers.componentDir)}`));
     console.log(chalk.dim(`  Blocks: ${path.resolve(process.cwd(), config.blockDir)}`));
-    console.log(chalk.dim(`  Theme: ${path.resolve(process.cwd(), config.theme)}\n`));
+    console.log(chalk.dim(`  Theme: ${path.resolve(process.cwd(), config.theme)}`));
+    console.log(chalk.dim('\n  Generate & save PDFs on the server (Node.js, API routes):'));
+    console.log(`  ${chalk.cyan(DOCS.SERVER_SIDE)}\n`);
   } catch (error: unknown) {
     posthog.captureException(error, distinctId);
     await shutdownPosthog();

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -10,6 +10,11 @@ export const REGISTRY_SUBPATHS = {
   BLOCKS: 'blocks',
 } as const;
 
+export const DOCS = {
+  /** Guide for generating and saving PDFs from Node.js / server-side environments. */
+  SERVER_SIDE: 'https://pdfx.akashpise.dev/docs/server-side',
+} as const;
+
 export const REQUIRED_VERSIONS = {
   '@react-pdf/renderer': '>=3.0.0',
   react: '>=16.8.0',


### PR DESCRIPTION
This pull request enhances the PDFx CLI documentation and user experience by introducing clear guidance and support for server-side PDF generation in Node.js environments. It adds a new documentation section and improves CLI output to help users discover and implement server-side PDF workflows more easily.

**Documentation and User Guidance Improvements:**

* Added a new "Server-side / Node.js" section to the `README.md`, including example usage of `@react-pdf/renderer`'s server-side rendering functions and a link to the full guide.
* After CLI initialization, the user is now shown a direct link to the server-side PDF generation documentation for easier discovery.

**Codebase Enhancements:**

* Introduced a new `DOCS` constant in `constants.ts` to centralize documentation URLs, starting with the server-side guide.
* Updated CLI imports to include the new `DOCS` constant.
ISSUE FIX - https://github.com/akii09/pdfx/issues/69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive server-side/Node.js documentation section with TypeScript/React examples and links to full guides.

* **Enhancements**
  * CLI initialization now displays server-side PDF generation instructions in the post-setup success message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->