### PR TITLE
fix(cli): eliminate EPIPE crashes and add "did you mean" suggestions

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -4,6 +4,7 @@ import {
   type Config,
   ConfigError,
   NetworkError,
+  PdfxError,
   RegistryError,
   type RegistryItem,
   ValidationError,
@@ -26,6 +27,8 @@ import {
 } from '../utils/package-manager.js';
 import { distinctId, posthog, shutdownPosthog } from '../utils/posthog.js';
 import { readJsonFile } from '../utils/read-json.js';
+import { fetchRegistryNames } from '../utils/registry-index.js';
+import { buildNotFoundSuggestion } from '../utils/suggest.js';
 
 type DependencyInstallMode = 'prompt' | 'always' | 'never';
 
@@ -82,11 +85,14 @@ export async function fetchComponent(name: string, registryUrl: string): Promise
   }
 
   if (!response.ok) {
-    throw new RegistryError(
-      response.status === 404
-        ? `Component "${name}" not found in registry`
-        : `Registry returned HTTP ${response.status}`
-    );
+    if (response.status === 404) {
+      const available = await fetchRegistryNames(registryUrl, 'registry:ui');
+      throw new RegistryError(
+        `Component "${name}" not found in registry`,
+        buildNotFoundSuggestion(name, available, 'npx pdfx-cli@latest list')
+      );
+    }
+    throw new RegistryError(`Registry returned HTTP ${response.status}`);
   }
 
   let data: unknown;
@@ -470,6 +476,9 @@ export async function add(components: string[], options: AddOptions = {}) {
       spinner.fail(`Failed to resolve ${componentName}`);
       const message = error instanceof Error ? error.message : String(error);
       console.error(chalk.dim(`  ${message}`));
+      if (error instanceof PdfxError && error.suggestion) {
+        console.log(chalk.dim(`  Hint: ${error.suggestion}`));
+      }
       failed.push(componentName);
     }
   }

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -86,10 +86,17 @@ export async function fetchComponent(name: string, registryUrl: string): Promise
 
   if (!response.ok) {
     if (response.status === 404) {
-      const available = await fetchRegistryNames(registryUrl, 'registry:ui');
+      const available = await fetchRegistryNames(registryUrl);
       throw new RegistryError(
         `Component "${name}" not found in registry`,
-        buildNotFoundSuggestion(name, available, 'npx pdfx-cli@latest list')
+        buildNotFoundSuggestion(name, {
+          kind: 'component',
+          sameKind: available.components,
+          otherKind: 'block',
+          otherKindNames: available.blocks,
+          otherKindCommand: 'npx pdfx-cli@latest block add',
+          listCommand: 'npx pdfx-cli@latest list',
+        })
       );
     }
     throw new RegistryError(`Registry returned HTTP ${response.status}`);

--- a/packages/cli/src/commands/block.ts
+++ b/packages/cli/src/commands/block.ts
@@ -17,6 +17,8 @@ import { DEFAULTS, FETCH_TIMEOUT_MS, REGISTRY_SUBPATHS } from '../constants.js';
 import { checkFileExists, ensureDir, safePath, writeFile } from '../utils/file-system.js';
 import { generateThemeContextFile } from '../utils/generate-theme.js';
 import { distinctId, posthog, shutdownPosthog } from '../utils/posthog.js';
+import { fetchRegistryNames } from '../utils/registry-index.js';
+import { buildNotFoundSuggestion } from '../utils/suggest.js';
 import { fetchComponent, readConfig, resolveThemeImport } from './add.js';
 
 type OverwriteDecision = 'skip' | 'overwrite' | 'overwrite-all';
@@ -35,14 +37,14 @@ async function fetchBlock(name: string, registryUrl: string): Promise<RegistryIt
   }
 
   if (!response.ok) {
-    throw new RegistryError(
-      response.status === 404
-        ? `Block "${name}" not found in registry`
-        : `Registry returned HTTP ${response.status}`,
-      response.status === 404
-        ? 'Run "npx pdfx-cli@latest block list" to see all available blocks'
-        : undefined
-    );
+    if (response.status === 404) {
+      const available = await fetchRegistryNames(registryUrl, 'registry:block');
+      throw new RegistryError(
+        `Block "${name}" not found in registry`,
+        buildNotFoundSuggestion(name, available, 'npx pdfx-cli@latest block list')
+      );
+    }
+    throw new RegistryError(`Registry returned HTTP ${response.status}`);
   }
 
   let data: unknown;

--- a/packages/cli/src/commands/block.ts
+++ b/packages/cli/src/commands/block.ts
@@ -38,10 +38,17 @@ async function fetchBlock(name: string, registryUrl: string): Promise<RegistryIt
 
   if (!response.ok) {
     if (response.status === 404) {
-      const available = await fetchRegistryNames(registryUrl, 'registry:block');
+      const available = await fetchRegistryNames(registryUrl);
       throw new RegistryError(
         `Block "${name}" not found in registry`,
-        buildNotFoundSuggestion(name, available, 'npx pdfx-cli@latest block list')
+        buildNotFoundSuggestion(name, {
+          kind: 'block',
+          sameKind: available.blocks,
+          otherKind: 'component',
+          otherKindNames: available.components,
+          otherKindCommand: 'npx pdfx-cli@latest add',
+          listCommand: 'npx pdfx-cli@latest block list',
+        })
       );
     }
     throw new RegistryError(`Registry returned HTTP ${response.status}`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,10 @@ import { list } from './commands/list.js';
 import { mcpCommand } from './commands/mcp.js';
 import { skillsCommand } from './commands/skills.js';
 import { themeInit, themeSwitch, themeValidate } from './commands/theme.js';
+import { installEpipeGuards } from './utils/safe-output.js';
+
+// Must run before any command can write to stdout/stderr.
+installEpipeGuards();
 
 function getVersion(): string {
   try {

--- a/packages/cli/src/utils/posthog.test.ts
+++ b/packages/cli/src/utils/posthog.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { posthog, shutdownPosthog } from './posthog.js';
+
+/**
+ * Unit tests for the telemetry flush.
+ *
+ * "Timeout while shutting down PostHog" was a recurring reported error: the rejection
+ * escaped `shutdownPosthog`, and because exception autocapture is enabled, our own
+ * analytics timeout was reported as though the CLI itself had failed.
+ */
+
+describe('shutdownPosthog', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reports success when the flush completes', async () => {
+    vi.spyOn(posthog, 'shutdown').mockResolvedValue(undefined);
+    await expect(shutdownPosthog()).resolves.toBe(true);
+  });
+
+  it('caps the flush at 3 seconds so the CLI never hangs', async () => {
+    const shutdown = vi.spyOn(posthog, 'shutdown').mockResolvedValue(undefined);
+    await shutdownPosthog();
+    expect(shutdown).toHaveBeenCalledWith(3000);
+  });
+
+  it('resolves false instead of rejecting when the flush times out', async () => {
+    vi.spyOn(posthog, 'shutdown').mockRejectedValue(
+      new Error('Timeout while shutting down PostHog. Some events may not have been sent.')
+    );
+    // Must not reject: an escaping rejection is what autocapture reported as a CLI error.
+    await expect(shutdownPosthog()).resolves.toBe(false);
+  });
+
+  it('resolves false when the flush fails for any other reason', async () => {
+    vi.spyOn(posthog, 'shutdown').mockRejectedValue(new Error('network unreachable'));
+    await expect(shutdownPosthog()).resolves.toBe(false);
+  });
+});

--- a/packages/cli/src/utils/posthog.ts
+++ b/packages/cli/src/utils/posthog.ts
@@ -17,14 +17,20 @@ export const distinctId = getDistinctId();
 /**
  * Flushes pending events with a 3-second cap so the CLI never hangs on network issues.
  *
- * A failed flush is swallowed deliberately. Telemetry is best-effort: the user cannot
- * act on it, and letting the rejection escape means exception autocapture reports our
- * own analytics timeout as if it were a CLI failure.
+ * Returns whether the flush completed, turning a failure into a value the caller can
+ * inspect rather than an exception that escapes. The rejection must not propagate:
+ * telemetry is best-effort, the user cannot act on it, and an escaping rejection is
+ * picked up by exception autocapture — which reported our own analytics timeout as if
+ * it were a CLI failure.
+ *
+ * Commands intentionally ignore the result today; it exists so a dropped batch is an
+ * explicit outcome rather than a discarded error.
  */
-export async function shutdownPosthog(): Promise<void> {
+export async function shutdownPosthog(): Promise<boolean> {
   try {
     await posthog.shutdown(3000);
+    return true;
   } catch {
-    // Best-effort flush — a dropped analytics batch is never worth surfacing.
+    return false;
   }
 }

--- a/packages/cli/src/utils/posthog.ts
+++ b/packages/cli/src/utils/posthog.ts
@@ -14,7 +14,17 @@ export const posthog = new PostHog('phc_zMnenjjttpwQD7tKQKzgpiSvwpv3KcLG96kR2tYv
 
 export const distinctId = getDistinctId();
 
-/** Shutdown with a 3-second cap so the CLI never hangs on network issues. */
+/**
+ * Flushes pending events with a 3-second cap so the CLI never hangs on network issues.
+ *
+ * A failed flush is swallowed deliberately. Telemetry is best-effort: the user cannot
+ * act on it, and letting the rejection escape means exception autocapture reports our
+ * own analytics timeout as if it were a CLI failure.
+ */
 export async function shutdownPosthog(): Promise<void> {
-  await posthog.shutdown(3000);
+  try {
+    await posthog.shutdown(3000);
+  } catch {
+    // Best-effort flush — a dropped analytics batch is never worth surfacing.
+  }
 }

--- a/packages/cli/src/utils/registry-index.ts
+++ b/packages/cli/src/utils/registry-index.ts
@@ -1,34 +1,45 @@
 import { registrySchema } from '@pdfx/shared';
 import { FETCH_TIMEOUT_MS } from '../constants.js';
 
-/** Item types as they appear in the registry index. Components are published as `registry:ui`. */
-export type RegistryItemType = 'registry:ui' | 'registry:block';
+/** Registry names split by kind. Components are published as `registry:ui`. */
+export interface RegistryNames {
+  components: string[];
+  blocks: string[];
+}
+
+function noNames(): RegistryNames {
+  return { components: [], blocks: [] };
+}
 
 /**
- * Fetches the names of every registry item of the given type.
+ * Fetches every component and block name from the registry index.
  *
- * This only feeds "did you mean" suggestions after a lookup has already failed, so it
- * never throws: an unreachable or malformed index simply means no suggestions to offer,
- * and the caller falls back to the plain not-found message. Surfacing a second error
- * here would replace a useful message with a confusing one.
+ * Both kinds come from one request so a failed lookup can suggest across them — the
+ * common miss is `pdfx add invoice`, where the matches are blocks rather than
+ * components.
+ *
+ * This only feeds suggestions after a lookup has already failed, so it never throws: an
+ * unreachable or malformed index simply means no suggestions to offer, and the caller
+ * falls back to the plain not-found message. Surfacing a second error here would
+ * replace a useful message with a confusing one.
  */
-export async function fetchRegistryNames(
-  registryUrl: string,
-  type: RegistryItemType
-): Promise<string[]> {
+export async function fetchRegistryNames(registryUrl: string): Promise<RegistryNames> {
   try {
     const response = await fetch(`${registryUrl}/index.json`, {
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
 
-    if (!response.ok) return [];
+    if (!response.ok) return noNames();
 
     const result = registrySchema.safeParse(await response.json());
-    if (!result.success) return [];
+    if (!result.success) return noNames();
 
-    return result.data.items.filter((item) => item.type === type).map((item) => item.name);
+    const namesOfType = (type: string) =>
+      result.data.items.filter((item) => item.type === type).map((item) => item.name);
+
+    return { components: namesOfType('registry:ui'), blocks: namesOfType('registry:block') };
   } catch {
     // Best-effort lookup on an error path — the original not-found error still stands.
-    return [];
+    return noNames();
   }
 }

--- a/packages/cli/src/utils/registry-index.ts
+++ b/packages/cli/src/utils/registry-index.ts
@@ -1,0 +1,34 @@
+import { registrySchema } from '@pdfx/shared';
+import { FETCH_TIMEOUT_MS } from '../constants.js';
+
+/** Item types as they appear in the registry index. Components are published as `registry:ui`. */
+export type RegistryItemType = 'registry:ui' | 'registry:block';
+
+/**
+ * Fetches the names of every registry item of the given type.
+ *
+ * This only feeds "did you mean" suggestions after a lookup has already failed, so it
+ * never throws: an unreachable or malformed index simply means no suggestions to offer,
+ * and the caller falls back to the plain not-found message. Surfacing a second error
+ * here would replace a useful message with a confusing one.
+ */
+export async function fetchRegistryNames(
+  registryUrl: string,
+  type: RegistryItemType
+): Promise<string[]> {
+  try {
+    const response = await fetch(`${registryUrl}/index.json`, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+
+    if (!response.ok) return [];
+
+    const result = registrySchema.safeParse(await response.json());
+    if (!result.success) return [];
+
+    return result.data.items.filter((item) => item.type === type).map((item) => item.name);
+  } catch {
+    // Best-effort lookup on an error path — the original not-found error still stands.
+    return [];
+  }
+}

--- a/packages/cli/src/utils/safe-output.test.ts
+++ b/packages/cli/src/utils/safe-output.test.ts
@@ -1,0 +1,71 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { handleStreamError, installEpipeGuards } from './safe-output.js';
+
+/**
+ * Unit tests for the EPIPE guards.
+ *
+ * EPIPE was the CLI's most frequent reported error: writing to a pipe whose reader has
+ * already closed (`pdfx list | head`, an MCP client disconnecting mid-response) raised
+ * an uncaught exception because nothing listened for stream errors.
+ */
+
+function epipe(): NodeJS.ErrnoException {
+  const err: NodeJS.ErrnoException = new Error('write EPIPE');
+  err.code = 'EPIPE';
+  return err;
+}
+
+describe('handleStreamError', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exits successfully on EPIPE', () => {
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exit called');
+    }) as never);
+
+    expect(() => handleStreamError(epipe())).toThrow('exit called');
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it('rethrows non-EPIPE stream errors so real failures stay visible', () => {
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    const err: NodeJS.ErrnoException = new Error('disk full');
+    err.code = 'ENOSPC';
+
+    expect(() => handleStreamError(err)).toThrow('disk full');
+    expect(exit).not.toHaveBeenCalled();
+  });
+});
+
+describe('installEpipeGuards', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('attaches a listener to every stream it is given', () => {
+    const a = new EventEmitter();
+    const b = new EventEmitter();
+
+    installEpipeGuards([a, b]);
+
+    expect(a.listenerCount('error')).toBe(1);
+    expect(b.listenerCount('error')).toBe(1);
+  });
+
+  it('routes an EPIPE emitted on a guarded stream to a clean exit', () => {
+    // process.exit never returns, so the mock throws a sentinel to model that; without
+    // it the handler would fall through to the rethrow below.
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exit called');
+    }) as never);
+    const stream = new EventEmitter();
+
+    installEpipeGuards([stream]);
+    // Without a listener this would be an uncaught 'error' event and crash the process.
+    expect(() => stream.emit('error', epipe())).toThrow('exit called');
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+});

--- a/packages/cli/src/utils/safe-output.ts
+++ b/packages/cli/src/utils/safe-output.ts
@@ -1,0 +1,26 @@
+/**
+ * Guards against EPIPE errors on the process output streams.
+ *
+ * When the CLI writes to a pipe whose reader has already closed — `pdfx list | head`,
+ * `pdfx add card > /dev/null`, or an MCP client disconnecting mid-response — Node emits
+ * an `EPIPE` error on the stream. With no listener attached this becomes an uncaught
+ * exception, which is both noise for the user and a false error report in telemetry.
+ *
+ * There is nothing left to write to and nothing the user can act on, so the correct
+ * behavior is a silent, successful exit. Non-EPIPE stream errors are left to bubble as
+ * before, since those are real failures worth surfacing.
+ */
+export function handleStreamError(err: NodeJS.ErrnoException): void {
+  if (err.code === 'EPIPE') {
+    process.exit(0);
+  }
+  throw err;
+}
+
+export function installEpipeGuards(
+  streams: NodeJS.EventEmitter[] = [process.stdout, process.stderr]
+): void {
+  for (const stream of streams) {
+    stream.on('error', handleStreamError);
+  }
+}

--- a/packages/cli/src/utils/suggest.test.ts
+++ b/packages/cli/src/utils/suggest.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { buildNotFoundSuggestion, findSimilarNames } from './suggest.js';
+
+/**
+ * Unit tests for registry name suggestions.
+ *
+ * The motivating case is `pdfx block add invoice`: no block is named plain `invoice`,
+ * but six `invoice-*` blocks exist. Before suggestions this produced a bare "not found"
+ * and users retried the same wrong name repeatedly.
+ */
+
+const BLOCKS = [
+  'invoice-classic',
+  'invoice-consultant',
+  'invoice-corporate',
+  'invoice-creative',
+  'invoice-minimal',
+  'invoice-modern',
+  'report-financial',
+  'report-marketing',
+  'report-operations',
+  'report-security',
+];
+
+const COMPONENTS = ['alert', 'badge', 'card', 'data-table', 'divider', 'heading', 'table', 'text'];
+
+describe('findSimilarNames: family prefixes', () => {
+  it('surfaces the invoice family when the user types the bare prefix', () => {
+    const result = findSimilarNames('invoice', BLOCKS);
+    expect(result).toEqual(['invoice-classic', 'invoice-consultant', 'invoice-corporate']);
+  });
+
+  it('caps suggestions at three even when many candidates match', () => {
+    expect(findSimilarNames('report', BLOCKS)).toHaveLength(3);
+  });
+
+  it('matches case-insensitively', () => {
+    expect(findSimilarNames('INVOICE', BLOCKS)).toContain('invoice-classic');
+  });
+});
+
+describe('findSimilarNames: typos', () => {
+  it('catches a single-character typo', () => {
+    expect(findSimilarNames('tabel', COMPONENTS)).toContain('table');
+  });
+
+  it('catches a missing character', () => {
+    expect(findSimilarNames('divder', COMPONENTS)).toContain('divider');
+  });
+
+  it('ignores a name too far from anything real', () => {
+    // "diner" is 3 edits from "divider" — past the threshold, and guessing here would
+    // be worse than saying nothing.
+    expect(findSimilarNames('diner', COMPONENTS)).toEqual([]);
+  });
+
+  it('ranks substring matches ahead of edit-distance matches', () => {
+    // "tabl" is a substring of both "table" and "data-table"; "text" is only a
+    // distance neighbour, so it must not outrank either.
+    const result = findSimilarNames('tabl', COMPONENTS);
+    expect(result.slice(0, 2)).toEqual(['data-table', 'table']);
+  });
+});
+
+describe('findSimilarNames: no match', () => {
+  it('returns nothing for a name unlike anything in the registry', () => {
+    expect(findSimilarNames('spreadsheet', BLOCKS)).toEqual([]);
+  });
+
+  it('returns nothing when the candidate list is empty', () => {
+    expect(findSimilarNames('invoice', [])).toEqual([]);
+  });
+
+  it('does not substring-match on a query too short to be meaningful', () => {
+    // "x" appears inside "text", but suggesting it would be noise, not help.
+    expect(findSimilarNames('x', COMPONENTS)).toEqual([]);
+  });
+});
+
+describe('buildNotFoundSuggestion', () => {
+  it('includes both the suggestions and the list command when matches exist', () => {
+    const hint = buildNotFoundSuggestion('invoice', BLOCKS, 'npx pdfx-cli@latest block list');
+    expect(hint).toContain('Did you mean: invoice-classic, invoice-consultant, invoice-corporate?');
+    expect(hint).toContain('npx pdfx-cli@latest block list');
+  });
+
+  it('falls back to only the list command when nothing is similar', () => {
+    const hint = buildNotFoundSuggestion('spreadsheet', BLOCKS, 'npx pdfx-cli@latest block list');
+    expect(hint).not.toContain('Did you mean');
+    expect(hint).toBe('Run "npx pdfx-cli@latest block list" to see everything available');
+  });
+
+  it('falls back to only the list command when the registry index was unreachable', () => {
+    // fetchRegistryNames returns [] rather than throwing when the index cannot be read.
+    const hint = buildNotFoundSuggestion('invoice', [], 'npx pdfx-cli@latest block list');
+    expect(hint).toBe('Run "npx pdfx-cli@latest block list" to see everything available');
+  });
+});

--- a/packages/cli/src/utils/suggest.test.ts
+++ b/packages/cli/src/utils/suggest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildNotFoundSuggestion, findSimilarNames } from './suggest.js';
+import { type NotFoundContext, buildNotFoundSuggestion, findSimilarNames } from './suggest.js';
 
 /**
  * Unit tests for registry name suggestions.
@@ -77,22 +77,78 @@ describe('findSimilarNames: no match', () => {
   });
 });
 
-describe('buildNotFoundSuggestion', () => {
+/** Context for a failed `pdfx block add`. */
+function blockContext(overrides: Partial<NotFoundContext> = {}): NotFoundContext {
+  return {
+    kind: 'block',
+    sameKind: BLOCKS,
+    otherKind: 'component',
+    otherKindNames: COMPONENTS,
+    otherKindCommand: 'npx pdfx-cli@latest add',
+    listCommand: 'npx pdfx-cli@latest block list',
+    ...overrides,
+  };
+}
+
+/** Context for a failed `pdfx add`. */
+function componentContext(overrides: Partial<NotFoundContext> = {}): NotFoundContext {
+  return {
+    kind: 'component',
+    sameKind: COMPONENTS,
+    otherKind: 'block',
+    otherKindNames: BLOCKS,
+    otherKindCommand: 'npx pdfx-cli@latest block add',
+    listCommand: 'npx pdfx-cli@latest list',
+    ...overrides,
+  };
+}
+
+describe('buildNotFoundSuggestion: same-kind matches', () => {
   it('includes both the suggestions and the list command when matches exist', () => {
-    const hint = buildNotFoundSuggestion('invoice', BLOCKS, 'npx pdfx-cli@latest block list');
+    const hint = buildNotFoundSuggestion('invoice', blockContext());
     expect(hint).toContain('Did you mean: invoice-classic, invoice-consultant, invoice-corporate?');
     expect(hint).toContain('npx pdfx-cli@latest block list');
   });
 
-  it('falls back to only the list command when nothing is similar', () => {
-    const hint = buildNotFoundSuggestion('spreadsheet', BLOCKS, 'npx pdfx-cli@latest block list');
+  it('prefers a same-kind match over any cross-kind match', () => {
+    // "table" is a component; nothing in BLOCKS is close to it.
+    const hint = buildNotFoundSuggestion('tabel', componentContext());
+    expect(hint).toContain('Did you mean: table?');
+    expect(hint).not.toContain('block add');
+  });
+});
+
+describe('buildNotFoundSuggestion: cross-kind matches', () => {
+  it('points at the block command when a component lookup matches blocks', () => {
+    // The reported failure: users ran `pdfx add invoice` / `block add invoice`.
+    const hint = buildNotFoundSuggestion('invoice', componentContext());
+    expect(hint).toBe(
+      'No component matches "invoice", but these blocks do: ' +
+        'invoice-classic, invoice-consultant, invoice-corporate. ' +
+        'Run "npx pdfx-cli@latest block add <name>"'
+    );
+  });
+
+  it('points at the component command when a block lookup matches components', () => {
+    const hint = buildNotFoundSuggestion('heading', blockContext());
+    expect(hint).toContain('No block matches "heading", but these components do: heading');
+    expect(hint).toContain('Run "npx pdfx-cli@latest add <name>"');
+  });
+});
+
+describe('buildNotFoundSuggestion: no matches', () => {
+  it('falls back to only the list command when nothing is similar in either kind', () => {
+    const hint = buildNotFoundSuggestion('spreadsheet', blockContext());
     expect(hint).not.toContain('Did you mean');
     expect(hint).toBe('Run "npx pdfx-cli@latest block list" to see everything available');
   });
 
   it('falls back to only the list command when the registry index was unreachable', () => {
-    // fetchRegistryNames returns [] rather than throwing when the index cannot be read.
-    const hint = buildNotFoundSuggestion('invoice', [], 'npx pdfx-cli@latest block list');
+    // fetchRegistryNames yields empty lists rather than throwing when the index fails.
+    const hint = buildNotFoundSuggestion(
+      'invoice',
+      blockContext({ sameKind: [], otherKindNames: [] })
+    );
     expect(hint).toBe('Run "npx pdfx-cli@latest block list" to see everything available');
   });
 });

--- a/packages/cli/src/utils/suggest.ts
+++ b/packages/cli/src/utils/suggest.ts
@@ -1,0 +1,91 @@
+/**
+ * Name suggestion helpers for failed registry lookups.
+ *
+ * When a user asks for a name the registry does not have — `pdfx block add invoice`
+ * when only `invoice-classic`, `invoice-modern`, … exist — a bare "not found" leaves
+ * them guessing. These helpers turn the miss into a short "did you mean" list.
+ *
+ * Kept dependency-free on purpose: this only serves an error path, and the CLI does not
+ * take on runtime dependencies for it.
+ */
+
+const MAX_SUGGESTIONS = 3;
+
+/**
+ * Shortest query eligible for substring matching. Below this almost every registry name
+ * contains the query (`x` is in `text`), which produces noise rather than a suggestion.
+ */
+const MIN_SUBSTRING_QUERY = 3;
+
+/**
+ * Levenshtein edit distance, computed with a single rolling row.
+ *
+ * Only used against the registry index (tens of names), so the O(n*m) cost is
+ * irrelevant here.
+ */
+function editDistance(a: string, b: string): number {
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+
+  for (let i = 1; i <= a.length; i++) {
+    const curr = [i];
+    for (let j = 1; j <= b.length; j++) {
+      curr[j] = Math.min(
+        prev[j] + 1,
+        curr[j - 1] + 1,
+        prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1)
+      );
+    }
+    prev = curr;
+  }
+
+  return prev[b.length];
+}
+
+/**
+ * Returns up to three registry names close to what the user typed.
+ *
+ * Substring matches rank first so that a family prefix like `invoice` surfaces every
+ * `invoice-*` entry ahead of any edit-distance neighbour. Remaining candidates qualify
+ * on edit distance, with the threshold scaled to the query length so short names do not
+ * match half the registry.
+ */
+export function findSimilarNames(name: string, candidates: string[]): string[] {
+  const query = name.toLowerCase();
+
+  const contains =
+    query.length >= MIN_SUBSTRING_QUERY
+      ? candidates
+          .filter((candidate) => candidate.toLowerCase().includes(query))
+          .sort((a, b) => a.localeCompare(b))
+      : [];
+
+  const threshold = Math.max(2, Math.floor(query.length / 3));
+  const near = candidates
+    .filter((candidate) => !contains.includes(candidate))
+    .map((candidate) => ({
+      name: candidate,
+      distance: editDistance(query, candidate.toLowerCase()),
+    }))
+    .filter((candidate) => candidate.distance <= threshold)
+    .sort((a, b) => a.distance - b.distance || a.name.localeCompare(b.name))
+    .map((candidate) => candidate.name);
+
+  return [...contains, ...near].slice(0, MAX_SUGGESTIONS);
+}
+
+/**
+ * Builds the hint shown under a "not found" error.
+ *
+ * Falls back to just the list command when nothing looks similar — or when the registry
+ * index could not be read, in which case `candidates` is empty.
+ */
+export function buildNotFoundSuggestion(
+  name: string,
+  candidates: string[],
+  listCommand: string
+): string {
+  const matches = findSimilarNames(name, candidates);
+  const listHint = `Run "${listCommand}" to see everything available`;
+
+  return matches.length > 0 ? `Did you mean: ${matches.join(', ')}? ${listHint}` : listHint;
+}

--- a/packages/cli/src/utils/suggest.ts
+++ b/packages/cli/src/utils/suggest.ts
@@ -73,19 +73,46 @@ export function findSimilarNames(name: string, candidates: string[]): string[] {
   return [...contains, ...near].slice(0, MAX_SUGGESTIONS);
 }
 
+export interface NotFoundContext {
+  /** What the user was installing: `component` for `add`, `block` for `block add`. */
+  kind: string;
+  /** Registry names of that kind. */
+  sameKind: string[];
+  /** The other kind's label, used when the match lives on the other command. */
+  otherKind: string;
+  /** Registry names of the other kind. */
+  otherKindNames: string[];
+  /** Command that installs from the other kind, e.g. `npx pdfx-cli@latest block add`. */
+  otherKindCommand: string;
+  /** Command that lists what the user was already looking for. */
+  listCommand: string;
+}
+
 /**
  * Builds the hint shown under a "not found" error.
  *
- * Falls back to just the list command when nothing looks similar — or when the registry
- * index could not be read, in which case `candidates` is empty.
+ * Prefers matches of the kind the user asked for. Failing that it looks across kinds:
+ * `pdfx add invoice` finds nothing under components, but six `invoice-*` blocks exist,
+ * and pointing at `block add` is more useful than a generic "run list".
+ *
+ * Falls back to the list command alone when nothing looks similar — including when the
+ * registry index could not be read, in which case both name lists are empty.
  */
-export function buildNotFoundSuggestion(
-  name: string,
-  candidates: string[],
-  listCommand: string
-): string {
-  const matches = findSimilarNames(name, candidates);
-  const listHint = `Run "${listCommand}" to see everything available`;
+export function buildNotFoundSuggestion(name: string, ctx: NotFoundContext): string {
+  const listHint = `Run "${ctx.listCommand}" to see everything available`;
 
-  return matches.length > 0 ? `Did you mean: ${matches.join(', ')}? ${listHint}` : listHint;
+  const matches = findSimilarNames(name, ctx.sameKind);
+  if (matches.length > 0) {
+    return `Did you mean: ${matches.join(', ')}? ${listHint}`;
+  }
+
+  const crossMatches = findSimilarNames(name, ctx.otherKindNames);
+  if (crossMatches.length > 0) {
+    return (
+      `No ${ctx.kind} matches "${name}", but these ${ctx.otherKind}s do: ` +
+      `${crossMatches.join(', ')}. Run "${ctx.otherKindCommand} <name>"`
+    );
+  }
+
+  return listHint;
 }


### PR DESCRIPTION
Addresses the top error sources in the all-time PostHog report
(732 events / 694 affected users).

## 1. EPIPE — 647 events, 647 unique users (88% of all errors)

`write EPIPE` (381) and `EPIPE: broken pipe, write` (266) were the single largest
source of reported errors, each hitting every affected user exactly once.

**Root cause:** nothing in the CLI listened for `error` on the output streams. When
the read end of a pipe closes first — `pdfx list | head`, `pdfx add card > /dev/null`,
or an MCP client disconnecting mid-response — Node raised an uncaught exception. With
`enableExceptionAutocapture` on, every one was also reported as a CLI error.

New `installEpipeGuards()` (`packages/cli/src/utils/safe-output.ts`) attaches handlers
to `stdout`/`stderr` before any command wiring, exiting 0 on EPIPE and rethrowing
everything else so real stream failures stay visible.

## 2. `Block "invoice" not found` — 36 events, 6 users

Not a regression — **no block named `invoice` has ever existed.** The registry ships
`invoice-classic`, `-consultant`, `-corporate`, `-creative`, `-minimal`, `-modern`.
Users typed the obvious name and retried ~6× each against a bare "not found".

Registry misses now suggest up to three near names, preferring same-kind matches and
falling back across kinds:
$ pdfx block add invoice
✖ Block "invoice" not found in registry
Hint: Did you mean: invoice-classic, invoice-consultant, invoice-corporate? …

$ pdfx add tabel
✖ Component "tabel" not found in registry
Hint: Did you mean: table? …

$ pdfx add invoice
✖ Component "invoice" not found in registry
Hint: No component matches "invoice", but these blocks do: invoice-classic,
invoice-consultant, invoice-corporate. Run "npx pdfx-cli@latest block add <name>"


Matching is substring-first (so a family prefix surfaces the whole family), then
Levenshtein within a length-scaled threshold. Implemented dependency-free.

Also fixes `add`'s resolve phase, which printed `error.message` but silently dropped
`error.suggestion` — so hints never reached users on the component path at all.

## 3. PostHog shutdown timeout — 46 events, 41 users

`shutdownPosthog()` already had a 3s cap, so the "call shutdown()" advice was already
implemented. The actual bug: the rejection escaped and exception autocapture reported
our own analytics timeout as a CLI failure. Now swallowed — telemetry is best-effort
and never actionable for the user.

## Behavior notes

- The registry index is fetched **only** after a lookup has already 404'd, and never
  throws: an unreachable index just means no suggestions, falling back to the plain
  message.
- No new runtime dependencies.
- No public API change — error text and exit codes only.

## Verification

| Check | Result |
|---|---|
| `pnpm test` | 316 passed (167 CLI, 20 new) |
| `pnpm typecheck` | pass |
| `pnpm lint` | pass |
| Manual, live registry | all 5 suggestion paths confirmed |

**Honest gap:** the EPIPE fix is verified by unit tests and by confirming the guard is
installed at the top of the shipped bundle — *not* by reproducing the original crash.
`pdfx list | head` and a destroyed-reader harness both exit cleanly on macOS (handled
via SIGPIPE there). The production traces point at `@modelcontextprotocol/sdk`, i.e.
async writes to a disconnected MCP transport, which I couldn't rig locally. The fix is
the standard Node remedy and is safe regardless, but the 88% reduction should be
treated as expected, not proven — worth watching the PostHog counter after release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced “component” and “block not found” messages with smarter “did you mean” suggestions, cross-kind guidance, and clearer next-step commands.
  * Improved suggestion quality by best-effort lookups of registry index names when available.
  * Prevented noisy CLI crashes on closed stdout/stderr (EPIPE) and made analytics shutdown best-effort.
* **Tests**
  * Added/expanded unit tests for suggestion ranking behavior, EPIPE-safe output handling, and resilient analytics shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->