### PR TITLE
chore: add changeset for CLI error handling fixes

### DIFF
--- a/.changeset/silent-pipes-suggest.md
+++ b/.changeset/silent-pipes-suggest.md
@@ -1,0 +1,9 @@
+---
+'pdfx-cli': patch
+---
+
+Fix EPIPE crashes when CLI output is piped to a command that exits early or an MCP
+client disconnects, which accounted for 88% of all reported CLI errors. Registry
+misses now suggest similar names — including across blocks and components, so
+`pdfx add invoice` points at the `invoice-*` blocks. PostHog flush timeouts are no
+longer reported as CLI failures.


### PR DESCRIPTION
## Description

Adds the missing changeset for the CLI error-handling fixes merged in #173.

#173 landed on `main` but shipped **no changeset**, so the Release workflow ran and
went green while doing nothing:

```
warn  pdfx-cli is not being published because version 0.6.1 is already published on npm
warn  No unpublished projects to publish
```

The fix for the CLI's most widespread error is therefore on `main` but not on npm —
`latest` and `beta` are both still `0.6.1`. This PR unblocks the release.

## Related Issue

Follow-up to #173. No issue to close.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [x] 🔧 Refactor / chore (no functional changes)

## Changes Made

- Adds `.changeset/silent-pipes-suggest.md` declaring a **patch** bump for `pdfx-cli`
  (`0.6.1` → `0.6.2`).

Patch rather than minor: #173 contained bug fixes and error-message improvements only,
with no public API change.

The changeset covers the three fixes from #173:

| Fix | Reported impact |
|---|---|
| EPIPE guards on stdout/stderr | 647 events / 647 unique users (88% of all errors) |
| "Did you mean" suggestions on registry misses | 36 events / 6 users (`Block "invoice" not found`) |
| PostHog flush timeout no longer reported as a CLI failure | 46 events / 41 users |

## How Has This Been Tested?

- [x] Unit tests pass (`pnpm test`)
- [x] Type checks pass (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint`)
- [x] Manually tested locally

Verified that Changesets actually picks this up — the failure mode being fixed here is
a release that silently no-ops:

```
$ pnpm changeset status --since=origin/main
🦋  info Packages to be bumped at patch:
🦋  - pdfx-cli
🦋  info NO packages to be bumped at minor
🦋  info NO packages to be bumped at major
```

Frontmatter confirmed well-formed at the byte level (this repo has previously shipped a
changeset with missing YAML front matter, which silently does nothing).

## Screenshots (if applicable)

N/A — no user-facing or PDF output change.

## Checklist

- [x] My code follows the project's style guidelines (Biome)
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests that prove my fix or feature works — N/A, metadata only
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation — N/A; the CHANGELOG is generated by Changesets
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format

## After merge

1. The Release workflow opens a **`chore: release packages`** PR bumping `pdfx-cli` to
   `0.6.2` and writing the CHANGELOG.
2. Merging *that* PR publishes to npm.
3. ⚠️ `pnpm release` is `changeset publish --tag beta`, so the publish sets `beta: 0.6.2`
   and leaves **`latest` at `0.6.1`**. Promote it explicitly, otherwise `npx pdfx-cli@latest`
   — the command the CLI's own error messages tell users to run — still serves the
   unfixed build:

   ```bash
   npm dist-tag add pdfx-cli@0.6.2 latest
   ```
