### PR TITLE
ci(release): surface npm auth failures instead of a misleading E404

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # npm answers an unauthenticated publish with "E404 Not Found" rather than 401/403,
+      # so an expired token surfaces as if the package did not exist — and only after the
+      # version bump has already been committed. Surface it up front instead.
+      # Warns rather than fails: opening the release PR does not need npm credentials.
+      - name: Check npm authentication
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if npm whoami > /dev/null 2>&1; then
+            echo "npm: authenticated as $(npm whoami)"
+          else
+            echo "::warning::npm authentication failed - NPM_TOKEN is missing, expired, or lacks publish access to pdfx-cli. Publishing will fail with a misleading E404. Rotate the token and update the repository secret."
+          fi
+
       - name: Create Release Pull Request or Publish
         uses: changesets/action@v1
         with:
@@ -44,4 +58,5 @@ jobs:
           commit: "chore: release packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description

The 0.6.2 publish failed in [run 29821880766](https://github.com/akii09/pdfx/actions/runs/29821880766) with:

```
🦋  info Publishing "pdfx-cli" at "0.6.2"
🦋  error E404 Not Found - PUT https://registry.npmjs.org/pdfx-cli - Not found
🦋  error 'pdfx-cli@0.6.2' is not in this registry.
```

`pdfx-cli` obviously *is* in the registry. npm answers an **unauthenticated or
unauthorized publish with 404** rather than 401/403, so it does not leak whether a
package exists. The real cause is credentials, and the log said so one line earlier:

```
No NPM_TOKEN or OIDC available - assuming npm is already authenticated
```

### Why it went unnoticed for three months

| Event | Date |
|---|---|
| `NPM_TOKEN` secret created | 2026-03-28 |
| First publish with it (0.4.1) | 2026-03-28 ✅ |
| **Last successful publish (0.6.1)** | **2026-04-10** ✅ |
| Release runs on 05-30, 06-16, 06-23 | all no-ops — "No unpublished projects to publish" |
| 0.6.2 publish attempt | 2026-07-21 ❌ |

Every release run between April and today was a no-op, so none of them exercised
authentication. The token is 115 days old at time of failure; npm granular tokens cap
at a 90-day expiry. Today was simply the first run that actually tried to publish.

The damaging part is the ordering: the version bump (#175) had **already merged**, so
`main` now says `0.6.2` while npm still serves `0.6.1`.

## Related Issue

Follow-up to #174 / #175. No issue to close.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🔧 Refactor / chore (no functional changes)

## Changes Made

`.github/workflows/release.yml`:

- **Adds a `Check npm authentication` step** before the release step. It runs
  `npm whoami` and, on failure, emits a `::warning::` naming the real cause instead of
  letting it surface later as a bogus E404.
- **Passes `NPM_TOKEN` to `changesets/action`** alongside the existing `NODE_AUTH_TOKEN`,
  so the action configures auth itself rather than logging *"assuming npm is already
  authenticated"*.

The check **warns rather than fails** on purpose: opening a release PR needs no npm
credentials, and an expired token should not block unrelated merges to `main`.

## ⚠️ This PR does not by itself fix the release

A workflow change cannot repair an expired credential. **The `NPM_TOKEN` secret must be
rotated**, and this PR only makes the next failure legible:

1. Create a new **Automation** token at <https://www.npmjs.com/settings/akii09/tokens>
   (Automation bypasses 2FA, which is required for CI publishing).
2. Update the repository secret `NPM_TOKEN`.
3. Re-run the failed job — no new version bump is needed, since `0.6.2` is already
   committed to `main` and unpublished, so `changeset publish` will pick it up.

## How Has This Been Tested?

- [ ] Unit tests pass (`pnpm test`) — N/A, CI config only
- [ ] Type checks pass (`pnpm typecheck`) — N/A
- [ ] Lint passes (`pnpm lint`) — N/A
- [x] Manually verified

Verified locally: no tab characters, all six steps aligned at the same indent level, and
the diff is additive only (+15 lines, no existing lines modified). No local YAML parser
was available, so final YAML validity is confirmed by GitHub accepting and running the
workflow on this PR.

## Screenshots (if applicable)

N/A — CI configuration only.

## Checklist

- [x] My code follows the project's style guidelines (Biome)
- [x] I have performed a self-review of my code
- [ ] I have added/updated tests — N/A, CI configuration
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation — N/A
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format

## Worth considering separately

- **npm Trusted Publishing (OIDC)** would remove long-lived tokens altogether and make
  this class of expiry impossible. It needs `permissions: id-token: write` plus trusted
  publisher configuration on npmjs.com, so it is deliberately out of scope here.
- **`pnpm release` publishes with `--tag beta`**, so `latest` must be promoted by hand
  after every release (`npm dist-tag add pdfx-cli@<version> latest`). If the beta phase
  is over, dropping that flag removes a manual step that is easy to forget.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release validation to detect missing, expired, or insufficient npm authentication before publishing.
  * Added clearer warnings when publishing credentials are unavailable, helping prevent misleading release errors.
  * Updated release credential handling for more reliable npm publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->